### PR TITLE
DE366491 : [Cordova][iOS] While selecting the OTP channel as SMS whic…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version 1.8.00
+
+### Bug fixes
+- MASUI's OTP channel selection screen was dismissed as soon as channel was selected which caused unexpected behaviour returning an internal OTP processing error to the original request. The Mobile SDK now prompts the internal OTP processing error on the channel selection screen, and the channel selection screen will only be dismissed upon cancellation of OTP process, and/or successful generation of OTP for the selected channel. [DE366491]
+
+
 # Version 1.7.00
 
 ### Bug fixes

--- a/MASUI/Classes/_private_/ui/otp/MASOTPChannelViewController.m
+++ b/MASUI/Classes/_private_/ui/otp/MASOTPChannelViewController.m
@@ -167,10 +167,10 @@
         //
         DLog(@"\n\ncalling otp generation block: %@\n\n", self.otpGenerationBlock);
         
+        __block UITableView *blockTableView = tableView;
+        __block NSIndexPath *blockIndexPath = indexPath;
         __block MASOTPChannelViewController *blockSelf = self;
-        self.otpGenerationBlock([_supportedChannels objectsAtIndexes:indicesOfItemsToSelect], NO,
-        ^(BOOL completed, NSError *error)
-        {
+        self.otpGenerationBlock([_supportedChannels objectsAtIndexes:indicesOfItemsToSelect], NO, ^(BOOL completed, NSError *error) {
                                     
             DLog(@"\n\nblock callback: %@ or error: %@\n\n", (completed ? @"Yes" : @"No"), [error localizedDescription]);
                                     
@@ -187,17 +187,22 @@
                 //
                 // Handle the error
                 //
-                if(error)
+                if (error)
                 {
                     [UIAlertController popupErrorAlert:error inViewController:blockSelf];
-                    
+                    [blockTableView deselectRowAtIndexPath:blockIndexPath animated:YES];
                     return;
                 }
-                                                       
                 //
-                // Dsmiss the view controller
+                //  Only close the screen if there is no error
                 //
-                [blockSelf dismissViewControllerAnimated:YES completion:nil];
+                else {
+                    
+                    //
+                    // Dsmiss the view controller
+                    //
+                    [blockSelf dismissViewControllerAnimated:YES completion:nil];
+                }
             });
             
         });
@@ -207,7 +212,7 @@
         [self.activityIndicator startAnimating];
         
         __block MASOTPChannelViewController *blockSelf = self;
-        self.otpGenerationBlock(nil, YES, ^(BOOL completed, NSError *error) {
+        self.otpGenerationBlock([NSArray array], YES, ^(BOOL completed, NSError *error) {
         
             //
             // Ensure this code runs in the main UI thread


### PR DESCRIPTION
…h is not configured, app throws Request failed message in the background as GET call.